### PR TITLE
Typo Deutsche -> Deutsch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository is intended to store all locale files for different languages.
 | Catalan               | Català                       | ca.json |
 | Czech                 | čeština                      | cs.json |
 | Danish                | dansk                        | da.json |
-| German                | Deutsche                     | de.json |
+| German                | Deutsch                      | de.json |
 | Greek                 | Ελληνικά                     | el.json |
 | English               | English                      | en.json |
 | Spanish               | Español                      | es.json |


### PR DESCRIPTION
The German language is called in German "Deutsch" where "Deutsche" are the people in German
We also call people "Deutsch" when they are from Germany. "Deutsche" would then be plural in that context(The people)